### PR TITLE
Dev for deploy valerii

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,13 +4,18 @@ spring:
     username: ${DB_USERNAME}
     driver-class-name: org.postgresql.Driver
     password: ${DB_PASSWORD}
+    hikari:
+        maximum-pool-size: 10
+        minimum-idle: 5
+        idle-timeout: 30000
+        max-lifetime: 600000
+        connection-timeout: 30000
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.xml
   jpa:
     properties:
       hibernate:
         auto_quote_keyword: true
-        #ddl-auto: create-drop
         ddl-auto: auto
         dialect: org.hibernate.dialect.PostgreSQLDialect
   mail:


### PR DESCRIPTION

Проблема "remaining connection slots are reserved for roles with the SUPERUSER attribute" возникает, когда у PostgreSQL не хватает доступных слотов соединений для обычных пользователей, потому что все слоты уже заняты или зарезервированы для суперпользователей.

datasource:
    hikari:
      maximum-pool-size: 10
      minimum-idle: 5
      idle-timeout: 30000
      max-lifetime: 600000
      connection-timeout: 30000